### PR TITLE
Fix typo in REDIS_COMMAND description

### DIFF
--- a/src/func_redis.c
+++ b/src/func_redis.c
@@ -119,7 +119,7 @@ void sdsfree(sds s) {
 		<description>
 			<para>Send a command to redis, all redis commands are valid
 			the result is saved in REDIS_RESULT, Example:
-			REDIS_COMMAND("SET key value")
+			REDIS_COMMAND(SET key value)
 			</para>
 		</description>
 		<see-also>


### PR DESCRIPTION
`REDIS_COMMAND("SET key value")` fails with `ERR unknown command '"SET'`.
