### PR TITLE
Fix build for Asterisk 13 and 14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/CMakeModules")
 
 project(func_redis)
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu99 -fms-extensions -shared -fPIC -Wall -pedantic -Wextra -Wno-unused-parameter")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu99 -fms-extensions -shared -fPIC -Wall -pedantic -Wextra -Wno-unused-parameter -DAST_MODULE_SELF_SYM=__internal_func_redis_self")
 
 set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -g -O0")
 

--- a/src/func_redis.c
+++ b/src/func_redis.c
@@ -30,7 +30,11 @@
 
 #include <asterisk.h>
 
+#ifdef ASTERISK_REGISTER_FILE
+ASTERISK_REGISTER_FILE()
+#else
 ASTERISK_FILE_VERSION("func_redis.c", "$Revision: 6 $")
+#endif
 
 #include <asterisk/module.h>
 #include <asterisk/channel.h>


### PR DESCRIPTION
ASTERISK_FILE_VERSION has been replaced with ASTERISK_REGISTER_FILE
when Asterisk project migrated to Git.

Asterisk 14 requires AST_MODULE_SELF_SYM to be defined for building
external modules.
